### PR TITLE
Faster (and more pixely) painting using pixel array

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,9 +14,12 @@ const vecLerp = (v1, v2, factor = .5) =>
 	)
 
 // Function to draw a point on the canvas
-function drawPoint(context, point, color) {
-	context.fillStyle = 'rgb(' + color[0] + ',' + color[1] + ',' + color[2] + ')'
-	context.fillRect(...point, 1, 1)
+function drawPoint(imageData, point, color) {
+	const idx = ((0|point[1]) * imageData.width + (0|point[0])) * 4;
+	imageData.data[idx] = color[0];
+	imageData.data[idx + 1] = color[1];
+	imageData.data[idx + 2] = color[2];
+	imageData.data[idx + 3] = 255;
 }
 
 const mod = (a, b) => (a % b + b) % b
@@ -25,6 +28,7 @@ const mod = (a, b) => (a % b + b) % b
 function initializeChaosGame(canvas, numPoints) {
 	var context = canvas.getContext('2d')
 	var canvasSize = [canvas.width, canvas.height]
+	const imageData = new ImageData(canvas.width, canvas.height);
 
 	// Clear the canvas
 	context.clearRect(0, 0, ...canvasSize);
@@ -91,8 +95,10 @@ function initializeChaosGame(canvas, numPoints) {
 		};
 
 		// Draw the midpoint
-		drawPoint(context, currentPoint.position, currentPoint.color)
+		drawPoint(imageData, currentPoint.position, currentPoint.color)
 	}
+
+	context.putImageData(imageData, 0, 0);
 }
 
 // Get the canvas element


### PR DESCRIPTION
This change writes all the pixel data to a pixel array, instead of using fillRect on every pixel. This is significantly faster.
However, it does not support the fractional pixel positioning that is currently used and instead clamps them to whole pixel positions.

This causes the resulting image to look significantly less blurry / more grainy. So it's up to you whether you want this change.

The old version:
![The old version](https://github.com/opensofias/chaos_game/assets/361185/938aa71a-dd09-45eb-a918-da549aaf9f0b)

The new version:
![The new version](https://github.com/opensofias/chaos_game/assets/361185/a3d4d577-8814-4cc4-bb4a-e0b00ccbead9)
